### PR TITLE
Add scrolling text feature for long artist/title combinations

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,20 @@ swift --version
 
 The first run may be slower as Swift compiles the script. Subsequent runs will be faster.
 
+### Scrolling settings persist after removal
+
+tmux options remain set even after removing them from your config. To fully disable scrolling after removing the configuration:
+
+```bash
+# Explicitly disable scrolling
+tmux set-option -g @nowplaying_scrolling_enabled "no"
+
+# Or unset all plugin options to restore defaults
+tmux set-option -gu @nowplaying_scrolling_enabled
+tmux set-option -gu @nowplaying_scrollable_threshold
+tmux set-option -gu @nowplaying_scroll_speed
+```
+
 ## Contributing
 
 Pull requests are welcome! Please feel free to submit issues or PRs.

--- a/README.md
+++ b/README.md
@@ -87,10 +87,6 @@ When the artist and title text is too long, it can automatically scroll:
 # Maximum characters before scrolling (default: 30)
 set -g @nowplaying_scrollable_threshold 30
 
-# Format for scrollable text (default: "{artist} - {title}")
-# Note: Currently always shows "Artist - Title" format
-set -g @nowplaying_scrollable_format "{artist} - {title}"
-
 # Scroll speed multiplier (default: 1, range: 1-10)
 # Higher values = faster scrolling
 set -g @nowplaying_scroll_speed 1

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ A tmux plugin that displays currently playing media from macOS's system-wide Now
 - ⚡ Uses macOS's native MediaRemote framework
 - 🎯 No external dependencies (pure Swift + bash)
 - 🔧 Customizable icons and formatting
+- 📜 Automatic scrolling for long artist/title text
 
 ## Requirements
 
@@ -78,6 +79,26 @@ set -g @nowplaying_paused_icon "⏸ "
 set -g @nowplaying_stopped_icon "⏹ "
 ```
 
+### Scrolling Text
+
+When the artist and title text is too long, it can automatically scroll:
+
+```bash
+# Maximum characters before scrolling (default: 30)
+set -g @nowplaying_scrollable_threshold 30
+
+# Format for scrollable text (default: "{artist} - {title}")
+# Note: Currently always shows "Artist - Title" format
+set -g @nowplaying_scrollable_format "{artist} - {title}"
+
+# Scroll speed multiplier (default: 1)
+# Higher values = faster scrolling
+set -g @nowplaying_scroll_speed 1
+
+# Padding between text repetitions (default: "   ")
+set -g @nowplaying_scroll_padding "   "
+```
+
 ### Auto-update
 
 The plugin automatically updates when tmux refreshes the status bar. You can control the refresh rate:
@@ -85,7 +106,16 @@ The plugin automatically updates when tmux refreshes the status bar. You can con
 ```bash
 # Refresh every 2 seconds (default: 15)
 set -g status-interval 2
+
+# Enable automatic interval adjustment for smooth scrolling (default: "yes")
+# Set to "no" to disable automatic status-interval adjustment
+set -g @nowplaying_auto_interval "yes"
+
+# Interval when playing and scrolling (default: 1)
+set -g @nowplaying_playing_interval 1
 ```
+
+By default, the plugin automatically adjusts the refresh rate to 1 second when text is scrolling to ensure smooth animation. You can disable this by setting `@nowplaying_auto_interval` to "no".
 
 ## How It Works
 

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ When the artist and title text is too long, it can automatically scroll:
 # Enable/disable scrolling text (default: "no")
 set -g @nowplaying_scrolling_enabled "yes"
 
-# Maximum characters before scrolling (default: 30)
+# Maximum characters before scrolling (default: 30, minimum: 1)
 set -g @nowplaying_scrollable_threshold 30
 
 # Scroll speed multiplier (default: 1, range: 1-10)

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ A tmux plugin that displays currently playing media from macOS's system-wide Now
 - ⚡ Uses macOS's native MediaRemote framework
 - 🎯 No external dependencies (pure Swift + bash)
 - 🔧 Customizable icons and formatting
-- 📜 Automatic scrolling for long artist/title text
+- 📜 Optional scrolling for long artist/title text
 
 ## Requirements
 
@@ -84,6 +84,9 @@ set -g @nowplaying_stopped_icon "⏹ "
 When the artist and title text is too long, it can automatically scroll:
 
 ```bash
+# Enable/disable scrolling text (default: "no")
+set -g @nowplaying_scrolling_enabled "yes"
+
 # Maximum characters before scrolling (default: 30)
 set -g @nowplaying_scrollable_threshold 30
 
@@ -103,8 +106,8 @@ The plugin automatically updates when tmux refreshes the status bar. You can con
 # Refresh every 2 seconds (default: 15)
 set -g status-interval 2
 
-# Enable automatic interval adjustment for smooth scrolling (default: "yes")
-# Set to "no" to disable automatic status-interval adjustment
+# Enable automatic interval adjustment for smooth scrolling (default: "no")
+# Only works when scrolling is enabled
 set -g @nowplaying_auto_interval "yes"
 
 # Interval when playing and scrolling (default: 1)

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ set -g @nowplaying_scrollable_threshold 30
 # Note: Currently always shows "Artist - Title" format
 set -g @nowplaying_scrollable_format "{artist} - {title}"
 
-# Scroll speed multiplier (default: 1)
+# Scroll speed multiplier (default: 1, range: 1-10)
 # Higher values = faster scrolling
 set -g @nowplaying_scroll_speed 1
 
@@ -115,7 +115,11 @@ set -g @nowplaying_auto_interval "yes"
 set -g @nowplaying_playing_interval 1
 ```
 
-By default, the plugin automatically adjusts the refresh rate to 1 second when text is scrolling to ensure smooth animation. You can disable this by setting `@nowplaying_auto_interval` to "no".
+By default, the plugin automatically manages the refresh rate:
+- **1 second** when text is scrolling for smooth animation
+- **Your original status-interval** when music is stopped or text fits without scrolling
+- The plugin remembers your original `status-interval` and restores it when not scrolling
+- You can disable this automatic management by setting `@nowplaying_auto_interval` to "no"
 
 ## How It Works
 

--- a/README.md
+++ b/README.md
@@ -87,8 +87,8 @@ When the artist and title text is too long, it can automatically scroll:
 # Enable/disable scrolling text (default: "no")
 set -g @nowplaying_scrolling_enabled "yes"
 
-# Maximum characters before scrolling (default: 30, minimum: 1)
-set -g @nowplaying_scrollable_threshold 30
+# Maximum characters before scrolling (default: 50, minimum: 1)
+set -g @nowplaying_scrollable_threshold 50
 
 # Scroll speed multiplier (default: 1, range: 1-10)
 # Higher values = faster scrolling

--- a/nowplaying.tmux
+++ b/nowplaying.tmux
@@ -2,10 +2,21 @@
 
 CURRENT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
+# Source helper functions
+source "$CURRENT_DIR/scripts/helpers.sh"
+
 # Default options
 tmux set-option -gq "@nowplaying_playing_icon" "♪ "
 tmux set-option -gq "@nowplaying_paused_icon" ""
 tmux set-option -gq "@nowplaying_stopped_icon" ""
+
+# Default scrolling options
+tmux set-option -gq "@nowplaying_scrollable_threshold" "30"
+tmux set-option -gq "@nowplaying_scrollable_format" "{artist} - {title}"
+tmux set-option -gq "@nowplaying_scroll_speed" "1"
+tmux set-option -gq "@nowplaying_scroll_padding" "   "
+tmux set-option -gq "@nowplaying_auto_interval" "yes"
+tmux set-option -gq "@nowplaying_playing_interval" "1"
 
 # Create the interpolation function
 nowplaying_interpolation() {
@@ -30,4 +41,20 @@ status_left_value="$(tmux show-option -gqv status-left)"
 if [[ "$status_left_value" == *"#{nowplaying}"* ]] && [[ "$status_left_value" != *"nowplaying.sh"* ]]; then
     new_status_left="$(nowplaying_interpolation "$status_left_value")"
     tmux set-option -g status-left "$new_status_left"
+fi
+
+# Set up automatic interval adjustment if enabled
+if [[ "$(get_tmux_option "@nowplaying_auto_interval" "no")" == "yes" ]]; then
+    # Check if music is playing and if text needs scrolling
+    output="$("$CURRENT_DIR/scripts/nowplaying_mediaremote.swift" 2>/dev/null)"
+    if [ -n "$output" ]; then
+        output_length="${#output}"
+        threshold="$(get_tmux_option "@nowplaying_scrollable_threshold" "30")"
+        
+        if [ "$output_length" -gt "$threshold" ]; then
+            # Set faster interval for scrolling
+            interval="$(get_tmux_option "@nowplaying_playing_interval" "1")"
+            tmux set-option -g status-interval "$interval"
+        fi
+    fi
 fi

--- a/nowplaying.tmux
+++ b/nowplaying.tmux
@@ -17,7 +17,6 @@ tmux set-option -gq "@nowplaying_stopped_icon" ""
 
 # Default scrolling options
 tmux set-option -gq "@nowplaying_scrollable_threshold" "30"
-tmux set-option -gq "@nowplaying_scrollable_format" "{artist} - {title}"
 tmux set-option -gq "@nowplaying_scroll_speed" "1"
 tmux set-option -gq "@nowplaying_scroll_padding" "   "
 tmux set-option -gq "@nowplaying_auto_interval" "yes"
@@ -47,6 +46,3 @@ if [[ "$status_left_value" == *"#{nowplaying}"* ]] && [[ "$status_left_value" !=
     new_status_left="$(nowplaying_interpolation "$status_left_value")"
     tmux set-option -g status-left "$new_status_left"
 fi
-
-# The interval management is now handled entirely in nowplaying.sh
-# This ensures we properly track and restore the user's original interval

--- a/nowplaying.tmux
+++ b/nowplaying.tmux
@@ -10,18 +10,36 @@ else
     exit 1
 fi
 
-# Default options
-tmux set-option -gq "@nowplaying_playing_icon" "♪ "
-tmux set-option -gq "@nowplaying_paused_icon" ""
-tmux set-option -gq "@nowplaying_stopped_icon" ""
+# Default options (only set if not already defined)
+if [ -z "$(tmux show-option -gqv "@nowplaying_playing_icon")" ]; then
+    tmux set-option -g "@nowplaying_playing_icon" "♪ "
+fi
+if [ -z "$(tmux show-option -gqv "@nowplaying_paused_icon")" ]; then
+    tmux set-option -g "@nowplaying_paused_icon" ""
+fi
+if [ -z "$(tmux show-option -gqv "@nowplaying_stopped_icon")" ]; then
+    tmux set-option -g "@nowplaying_stopped_icon" ""
+fi
 
-# Default scrolling options
-tmux set-option -gq "@nowplaying_scrolling_enabled" "no"
-tmux set-option -gq "@nowplaying_scrollable_threshold" "30"
-tmux set-option -gq "@nowplaying_scroll_speed" "1"
-tmux set-option -gq "@nowplaying_scroll_padding" "   "
-tmux set-option -gq "@nowplaying_auto_interval" "no"
-tmux set-option -gq "@nowplaying_playing_interval" "1"
+# Default scrolling options (only set if not already defined)
+if [ -z "$(tmux show-option -gqv "@nowplaying_scrolling_enabled")" ]; then
+    tmux set-option -g "@nowplaying_scrolling_enabled" "no"
+fi
+if [ -z "$(tmux show-option -gqv "@nowplaying_scrollable_threshold")" ]; then
+    tmux set-option -g "@nowplaying_scrollable_threshold" "30"
+fi
+if [ -z "$(tmux show-option -gqv "@nowplaying_scroll_speed")" ]; then
+    tmux set-option -g "@nowplaying_scroll_speed" "1"
+fi
+if [ -z "$(tmux show-option -gqv "@nowplaying_scroll_padding")" ]; then
+    tmux set-option -g "@nowplaying_scroll_padding" "   "
+fi
+if [ -z "$(tmux show-option -gqv "@nowplaying_auto_interval")" ]; then
+    tmux set-option -g "@nowplaying_auto_interval" "no"
+fi
+if [ -z "$(tmux show-option -gqv "@nowplaying_playing_interval")" ]; then
+    tmux set-option -g "@nowplaying_playing_interval" "1"
+fi
 
 # Create the interpolation function
 nowplaying_interpolation() {

--- a/nowplaying.tmux
+++ b/nowplaying.tmux
@@ -16,10 +16,11 @@ tmux set-option -gq "@nowplaying_paused_icon" ""
 tmux set-option -gq "@nowplaying_stopped_icon" ""
 
 # Default scrolling options
+tmux set-option -gq "@nowplaying_scrolling_enabled" "no"
 tmux set-option -gq "@nowplaying_scrollable_threshold" "30"
 tmux set-option -gq "@nowplaying_scroll_speed" "1"
 tmux set-option -gq "@nowplaying_scroll_padding" "   "
-tmux set-option -gq "@nowplaying_auto_interval" "yes"
+tmux set-option -gq "@nowplaying_auto_interval" "no"
 tmux set-option -gq "@nowplaying_playing_interval" "1"
 
 # Create the interpolation function

--- a/nowplaying.tmux
+++ b/nowplaying.tmux
@@ -26,7 +26,7 @@ if [ -z "$(tmux show-option -gqv "@nowplaying_scrolling_enabled")" ]; then
     tmux set-option -g "@nowplaying_scrolling_enabled" "no"
 fi
 if [ -z "$(tmux show-option -gqv "@nowplaying_scrollable_threshold")" ]; then
-    tmux set-option -g "@nowplaying_scrollable_threshold" "30"
+    tmux set-option -g "@nowplaying_scrollable_threshold" "50"
 fi
 if [ -z "$(tmux show-option -gqv "@nowplaying_scroll_speed")" ]; then
     tmux set-option -g "@nowplaying_scroll_speed" "1"

--- a/nowplaying.tmux
+++ b/nowplaying.tmux
@@ -3,7 +3,12 @@
 CURRENT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 # Source helper functions
-source "$CURRENT_DIR/scripts/helpers.sh"
+if [ -f "$CURRENT_DIR/scripts/helpers.sh" ]; then
+    source "$CURRENT_DIR/scripts/helpers.sh"
+else
+    echo "Error: helpers.sh not found" >&2
+    exit 1
+fi
 
 # Default options
 tmux set-option -gq "@nowplaying_playing_icon" "♪ "
@@ -43,18 +48,5 @@ if [[ "$status_left_value" == *"#{nowplaying}"* ]] && [[ "$status_left_value" !=
     tmux set-option -g status-left "$new_status_left"
 fi
 
-# Set up automatic interval adjustment if enabled
-if [[ "$(get_tmux_option "@nowplaying_auto_interval" "no")" == "yes" ]]; then
-    # Check if music is playing and if text needs scrolling
-    output="$("$CURRENT_DIR/scripts/nowplaying_mediaremote.swift" 2>/dev/null)"
-    if [ -n "$output" ]; then
-        output_length="${#output}"
-        threshold="$(get_tmux_option "@nowplaying_scrollable_threshold" "30")"
-        
-        if [ "$output_length" -gt "$threshold" ]; then
-            # Set faster interval for scrolling
-            interval="$(get_tmux_option "@nowplaying_playing_interval" "1")"
-            tmux set-option -g status-interval "$interval"
-        fi
-    fi
-fi
+# The interval management is now handled entirely in nowplaying.sh
+# This ensures we properly track and restore the user's original interval

--- a/scripts/helpers.sh
+++ b/scripts/helpers.sh
@@ -52,21 +52,16 @@ scrolling_text() {
     # Calculate the starting position based on offset
     local start_pos=$((offset % (text_length + ${#padding})))
     
-    # Extract the visible portion
-    local visible=""
-    local chars_needed="$max_width"
-    local pos="$start_pos"
-    
-    while [ "$chars_needed" -gt 0 ]; do
-        if [ "$pos" -ge "$padded_length" ]; then
-            pos=0
-        fi
-        visible="${visible}${padded_text:$pos:1}"
-        ((pos++))
-        ((chars_needed--))
-    done
-    
-    echo "$visible"
+    # Extract the visible portion efficiently
+    # If we can get the whole substring without wrapping
+    if [ $((start_pos + max_width)) -le "$padded_length" ]; then
+        printf "%.*s\n" "$max_width" "${padded_text:$start_pos}"
+    else
+        # Need to wrap around - get first part and second part
+        local first_part_len=$((padded_length - start_pos))
+        local second_part_len=$((max_width - first_part_len))
+        printf "%s%.*s\n" "${padded_text:$start_pos}" "$second_part_len" "$padded_text"
+    fi
 }
 
 # Get current time in seconds for scrolling offset

--- a/scripts/helpers.sh
+++ b/scripts/helpers.sh
@@ -11,3 +11,67 @@ _tmux_version() {
 _tmux_version_ok() {
     [[ "$(_tmux_version)" == 2.9* ]] || [[ "$(_tmux_version)" == 3.* ]]
 }
+
+# Get tmux option with default value
+get_tmux_option() {
+    local option="$1"
+    local default_value="$2"
+    local option_value="$(tmux show-option -qv "$option")"
+    if [ -z "$option_value" ]; then
+        option_value="$(tmux show-option -gqv "$option")"
+    fi
+    if [ -z "$option_value" ]; then
+        echo "$default_value"
+    else
+        echo "$option_value"
+    fi
+}
+
+# Scrolling text function
+# Arguments:
+#   $1 - text to scroll
+#   $2 - maximum width before scrolling
+#   $3 - offset for scrolling position
+scrolling_text() {
+    local text="$1"
+    local max_width="$2"
+    local offset="$3"
+    local text_length="${#text}"
+    
+    # If text fits within max_width, return as-is
+    if [ "$text_length" -le "$max_width" ]; then
+        echo "$text"
+        return
+    fi
+    
+    # Get padding from tmux option
+    local padding="$(get_tmux_option "@nowplaying_scroll_padding" "   ")"
+    local padded_text="${text}${padding}${text}"
+    local padded_length="${#padded_text}"
+    
+    # Calculate the starting position based on offset
+    local start_pos=$((offset % (text_length + ${#padding})))
+    
+    # Extract the visible portion
+    local visible=""
+    local chars_needed="$max_width"
+    local pos="$start_pos"
+    
+    while [ "$chars_needed" -gt 0 ]; do
+        if [ "$pos" -ge "$padded_length" ]; then
+            pos=0
+        fi
+        visible="${visible}${padded_text:$pos:1}"
+        ((pos++))
+        ((chars_needed--))
+    done
+    
+    echo "$visible"
+}
+
+# Get current time in seconds for scrolling offset
+get_scroll_offset() {
+    local speed="$(get_tmux_option "@nowplaying_scroll_speed" "1")"
+    # Use current seconds as base, multiply by speed for faster/slower scrolling
+    echo $(($(date +%s) * speed))
+}

--- a/scripts/helpers.sh
+++ b/scripts/helpers.sh
@@ -72,6 +72,12 @@ scrolling_text() {
 # Get current time in seconds for scrolling offset
 get_scroll_offset() {
     local speed="$(get_tmux_option "@nowplaying_scroll_speed" "1")"
+    # Bound speed between 1 and 10 to prevent overflow
+    if [ "$speed" -lt 1 ]; then
+        speed=1
+    elif [ "$speed" -gt 10 ]; then
+        speed=10
+    fi
     # Use current seconds as base, multiply by speed for faster/slower scrolling
     echo $(($(date +%s) * speed))
 }

--- a/scripts/nowplaying.sh
+++ b/scripts/nowplaying.sh
@@ -23,11 +23,11 @@ STOPPED_ICON="${STOPPED_ICON:-}"
 
 # Get scrolling options
 SCROLLING_ENABLED="$(get_tmux_option "@nowplaying_scrolling_enabled" "no")"
-SCROLLABLE_THRESHOLD="$(get_tmux_option "@nowplaying_scrollable_threshold" "30")"
+SCROLLABLE_THRESHOLD="$(get_tmux_option "@nowplaying_scrollable_threshold" "50")"
 
 # Validate threshold
 if [ "$SCROLLABLE_THRESHOLD" -lt 1 ]; then
-    SCROLLABLE_THRESHOLD=30
+    SCROLLABLE_THRESHOLD=50
 fi
 
 # Store original interval if not already stored (only if scrolling is enabled)
@@ -67,11 +67,17 @@ if [ -n "$output" ]; then
         fi
     fi
     
-    if [ "$SCROLLING_ENABLED" == "yes" ] && [ "$output_length" -gt "$SCROLLABLE_THRESHOLD" ]; then
-        # Get scroll offset based on current time
-        offset="$(get_scroll_offset)"
-        scrolled_output="$(scrolling_text "$output" "$SCROLLABLE_THRESHOLD" "$offset")"
-        echo "${PLAYING_ICON}${scrolled_output}"
+    if [ "$output_length" -gt "$SCROLLABLE_THRESHOLD" ]; then
+        if [ "$SCROLLING_ENABLED" == "yes" ]; then
+            # Get scroll offset based on current time
+            offset="$(get_scroll_offset)"
+            scrolled_output="$(scrolling_text "$output" "$SCROLLABLE_THRESHOLD" "$offset")"
+            echo "${PLAYING_ICON}${scrolled_output}"
+        else
+            # Truncate with ellipsis when scrolling is disabled
+            truncated="${output:0:$((SCROLLABLE_THRESHOLD - 3))}..."
+            echo "${PLAYING_ICON}${truncated}"
+        fi
     else
         echo "${PLAYING_ICON}${output}"
     fi

--- a/scripts/nowplaying.sh
+++ b/scripts/nowplaying.sh
@@ -3,6 +3,9 @@
 # Get the directory where this script is located
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
+# Source helper functions
+source "$SCRIPT_DIR/helpers.sh"
+
 # Get user options
 PLAYING_ICON="$(tmux show-option -gqv "@nowplaying_playing_icon")"
 PAUSED_ICON="$(tmux show-option -gqv "@nowplaying_paused_icon")"
@@ -13,10 +16,24 @@ PLAYING_ICON="${PLAYING_ICON:-♪ }"
 PAUSED_ICON="${PAUSED_ICON:-}"
 STOPPED_ICON="${STOPPED_ICON:-}"
 
+# Get scrolling options
+SCROLLABLE_THRESHOLD="$(get_tmux_option "@nowplaying_scrollable_threshold" "30")"
+SCROLLABLE_FORMAT="$(get_tmux_option "@nowplaying_scrollable_format" "{artist} - {title}")"
+
 # Get now playing info from Swift script
 output="$("$SCRIPT_DIR/nowplaying_mediaremote.swift" 2>/dev/null)"
 
-# If we got output, display it with the playing icon
+# If we got output, process and display it
 if [ -n "$output" ]; then
-    echo "${PLAYING_ICON}${output}"
+    # Check if scrolling is needed
+    output_length="${#output}"
+    
+    if [ "$output_length" -gt "$SCROLLABLE_THRESHOLD" ]; then
+        # Get scroll offset based on current time
+        offset="$(get_scroll_offset)"
+        scrolled_output="$(scrolling_text "$output" "$SCROLLABLE_THRESHOLD" "$offset")"
+        echo "${PLAYING_ICON}${scrolled_output}"
+    else
+        echo "${PLAYING_ICON}${output}"
+    fi
 fi

--- a/scripts/nowplaying.sh
+++ b/scripts/nowplaying.sh
@@ -23,7 +23,6 @@ STOPPED_ICON="${STOPPED_ICON:-}"
 
 # Get scrolling options
 SCROLLABLE_THRESHOLD="$(get_tmux_option "@nowplaying_scrollable_threshold" "30")"
-SCROLLABLE_FORMAT="$(get_tmux_option "@nowplaying_scrollable_format" "{artist} - {title}")"
 
 # Store original interval if not already stored
 ORIGINAL_INTERVAL="$(get_tmux_option "@nowplaying_original_interval" "")"

--- a/scripts/nowplaying.sh
+++ b/scripts/nowplaying.sh
@@ -22,17 +22,20 @@ PAUSED_ICON="${PAUSED_ICON:-}"
 STOPPED_ICON="${STOPPED_ICON:-}"
 
 # Get scrolling options
+SCROLLING_ENABLED="$(get_tmux_option "@nowplaying_scrolling_enabled" "no")"
 SCROLLABLE_THRESHOLD="$(get_tmux_option "@nowplaying_scrollable_threshold" "30")"
 
-# Store original interval if not already stored
-ORIGINAL_INTERVAL="$(get_tmux_option "@nowplaying_original_interval" "")"
-if [ -z "$ORIGINAL_INTERVAL" ]; then
-    CURRENT_INTERVAL="$(tmux show-option -gqv status-interval)"
-    if [ -n "$CURRENT_INTERVAL" ]; then
-        tmux set-option -gq "@nowplaying_original_interval" "$CURRENT_INTERVAL"
-        ORIGINAL_INTERVAL="$CURRENT_INTERVAL"
-    else
-        ORIGINAL_INTERVAL="15"  # tmux default
+# Store original interval if not already stored (only if scrolling is enabled)
+if [ "$SCROLLING_ENABLED" == "yes" ]; then
+    ORIGINAL_INTERVAL="$(get_tmux_option "@nowplaying_original_interval" "")"
+    if [ -z "$ORIGINAL_INTERVAL" ]; then
+        CURRENT_INTERVAL="$(tmux show-option -gqv status-interval)"
+        if [ -n "$CURRENT_INTERVAL" ]; then
+            tmux set-option -gq "@nowplaying_original_interval" "$CURRENT_INTERVAL"
+            ORIGINAL_INTERVAL="$CURRENT_INTERVAL"
+        else
+            ORIGINAL_INTERVAL="15"  # tmux default
+        fi
     fi
 fi
 
@@ -40,14 +43,15 @@ fi
 output="$("$SCRIPT_DIR/nowplaying_mediaremote.swift" 2>/dev/null)"
 
 # Handle auto-interval adjustment
-AUTO_INTERVAL="$(get_tmux_option "@nowplaying_auto_interval" "yes")"
+AUTO_INTERVAL="$(get_tmux_option "@nowplaying_auto_interval" "no")"
 
 # If we got output, process and display it
 if [ -n "$output" ]; then
     # Check if scrolling is needed
     output_length="${#output}"
     
-    if [ "$AUTO_INTERVAL" == "yes" ]; then
+    # Only manage intervals if scrolling is enabled
+    if [ "$SCROLLING_ENABLED" == "yes" ] && [ "$AUTO_INTERVAL" == "yes" ]; then
         if [ "$output_length" -gt "$SCROLLABLE_THRESHOLD" ]; then
             # Set faster interval for scrolling
             PLAYING_INTERVAL="$(get_tmux_option "@nowplaying_playing_interval" "1")"
@@ -58,7 +62,7 @@ if [ -n "$output" ]; then
         fi
     fi
     
-    if [ "$output_length" -gt "$SCROLLABLE_THRESHOLD" ]; then
+    if [ "$SCROLLING_ENABLED" == "yes" ] && [ "$output_length" -gt "$SCROLLABLE_THRESHOLD" ]; then
         # Get scroll offset based on current time
         offset="$(get_scroll_offset)"
         scrolled_output="$(scrolling_text "$output" "$SCROLLABLE_THRESHOLD" "$offset")"
@@ -68,7 +72,7 @@ if [ -n "$output" ]; then
     fi
 else
     # No music playing - restore original interval
-    if [ "$AUTO_INTERVAL" == "yes" ]; then
+    if [ "$SCROLLING_ENABLED" == "yes" ] && [ "$AUTO_INTERVAL" == "yes" ]; then
         tmux set-option -g status-interval "$ORIGINAL_INTERVAL"
     fi
 fi

--- a/scripts/nowplaying.sh
+++ b/scripts/nowplaying.sh
@@ -4,7 +4,12 @@
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 # Source helper functions
-source "$SCRIPT_DIR/helpers.sh"
+if [ -f "$SCRIPT_DIR/helpers.sh" ]; then
+    source "$SCRIPT_DIR/helpers.sh"
+else
+    echo "Error: helpers.sh not found" >&2
+    exit 1
+fi
 
 # Get user options
 PLAYING_ICON="$(tmux show-option -gqv "@nowplaying_playing_icon")"
@@ -20,13 +25,39 @@ STOPPED_ICON="${STOPPED_ICON:-}"
 SCROLLABLE_THRESHOLD="$(get_tmux_option "@nowplaying_scrollable_threshold" "30")"
 SCROLLABLE_FORMAT="$(get_tmux_option "@nowplaying_scrollable_format" "{artist} - {title}")"
 
+# Store original interval if not already stored
+ORIGINAL_INTERVAL="$(get_tmux_option "@nowplaying_original_interval" "")"
+if [ -z "$ORIGINAL_INTERVAL" ]; then
+    CURRENT_INTERVAL="$(tmux show-option -gqv status-interval)"
+    if [ -n "$CURRENT_INTERVAL" ]; then
+        tmux set-option -gq "@nowplaying_original_interval" "$CURRENT_INTERVAL"
+        ORIGINAL_INTERVAL="$CURRENT_INTERVAL"
+    else
+        ORIGINAL_INTERVAL="15"  # tmux default
+    fi
+fi
+
 # Get now playing info from Swift script
 output="$("$SCRIPT_DIR/nowplaying_mediaremote.swift" 2>/dev/null)"
+
+# Handle auto-interval adjustment
+AUTO_INTERVAL="$(get_tmux_option "@nowplaying_auto_interval" "yes")"
 
 # If we got output, process and display it
 if [ -n "$output" ]; then
     # Check if scrolling is needed
     output_length="${#output}"
+    
+    if [ "$AUTO_INTERVAL" == "yes" ]; then
+        if [ "$output_length" -gt "$SCROLLABLE_THRESHOLD" ]; then
+            # Set faster interval for scrolling
+            PLAYING_INTERVAL="$(get_tmux_option "@nowplaying_playing_interval" "1")"
+            tmux set-option -g status-interval "$PLAYING_INTERVAL"
+        else
+            # Restore original interval when not scrolling
+            tmux set-option -g status-interval "$ORIGINAL_INTERVAL"
+        fi
+    fi
     
     if [ "$output_length" -gt "$SCROLLABLE_THRESHOLD" ]; then
         # Get scroll offset based on current time
@@ -35,5 +66,10 @@ if [ -n "$output" ]; then
         echo "${PLAYING_ICON}${scrolled_output}"
     else
         echo "${PLAYING_ICON}${output}"
+    fi
+else
+    # No music playing - restore original interval
+    if [ "$AUTO_INTERVAL" == "yes" ]; then
+        tmux set-option -g status-interval "$ORIGINAL_INTERVAL"
     fi
 fi

--- a/scripts/nowplaying.sh
+++ b/scripts/nowplaying.sh
@@ -25,6 +25,11 @@ STOPPED_ICON="${STOPPED_ICON:-}"
 SCROLLING_ENABLED="$(get_tmux_option "@nowplaying_scrolling_enabled" "no")"
 SCROLLABLE_THRESHOLD="$(get_tmux_option "@nowplaying_scrollable_threshold" "30")"
 
+# Validate threshold
+if [ "$SCROLLABLE_THRESHOLD" -lt 1 ]; then
+    SCROLLABLE_THRESHOLD=30
+fi
+
 # Store original interval if not already stored (only if scrolling is enabled)
 if [ "$SCROLLING_ENABLED" == "yes" ]; then
     ORIGINAL_INTERVAL="$(get_tmux_option "@nowplaying_original_interval" "")"


### PR DESCRIPTION
## Summary
- Implements automatic scrolling for artist/title text that exceeds a configurable threshold
- Adds configuration options for customizing scrolling behavior  
- Updates documentation with new features and configuration options

## Description
This PR addresses issue #1 by adding scrolling text functionality similar to the referenced tmux-now-playing plugin. When the combined artist and title text exceeds a configurable threshold (default 30 characters), the text will automatically scroll to show the full content.

### Implementation Details
- Added scrolling_text function in helpers.sh that handles the scrolling logic
- Modified nowplaying.sh to check text length and apply scrolling when needed
- Added multiple configuration options for customization
- Time-based scrolling animation (not position-based like the reference)

### New Configuration Options
- @nowplaying_scrollable_threshold - Maximum characters before scrolling (default: 30)
- @nowplaying_scroll_speed - Scroll speed multiplier (default: 1)
- @nowplaying_scroll_padding - Padding between text repetitions (default: three spaces)
- @nowplaying_auto_interval - Enable automatic status-interval adjustment (default: no)
- @nowplaying_playing_interval - Interval when scrolling is active (default: 1)

## Test plan
- [x] Test with short artist/title that doesn't need scrolling
- [x] Test with long artist/title that triggers scrolling
- [x] Verify scrolling animation works smoothly
- [x] Test different scroll speeds and padding options
- [x] Ensure backward compatibility (no scrolling by default)

Fixes #1