### PR TITLE
scrolling: delete unreachable wrap branch

### DIFF
--- a/scripts/helpers.sh
+++ b/scripts/helpers.sh
@@ -209,22 +209,13 @@ scrolling_text() {
     # Get padding from tmux option
     local padding
     padding="$(get_nowplaying_option "@nowplaying_scroll_padding")"
+    # Duplicating the text handles slices that cross the scroll cycle boundary.
     local padded_text="${text}${padding}${text}"
-    local padded_length="${#padded_text}"
-    
+
     # Calculate the starting position based on offset
     local start_pos=$((offset % (text_length + ${#padding})))
-    
-    # Extract the visible portion efficiently
-    # If we can get the whole substring without wrapping
-    if [ $((start_pos + max_width)) -le "$padded_length" ]; then
-        printf "%.*s\n" "$max_width" "${padded_text:$start_pos}"
-    else
-        # Need to wrap around - get first part and second part
-        local first_part_len=$((padded_length - start_pos))
-        local second_part_len=$((max_width - first_part_len))
-        printf "%s%.*s\n" "${padded_text:$start_pos}" "$second_part_len" "$padded_text"
-    fi
+
+    printf '%.*s\n' "$max_width" "${padded_text:$start_pos}"
 }
 
 # Get current time in seconds for scrolling offset

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -67,6 +67,24 @@ assert_adapter_rejected() {
     assert_eq "" "$track_title" "${message} clears title"
 }
 
+assert_scrolling_text() {
+    local expected="$1"
+    local text="$2"
+    local width="$3"
+    local padding="$4"
+    local offset="$5"
+    local message="$6"
+    local actual
+
+    actual="$(bash -c '
+        source "$1"
+        scroll_padding="$5"
+        get_nowplaying_option() { printf "%s" "$scroll_padding"; }
+        scrolling_text "$2" "$3" "$4"
+    ' _ "${ROOT_DIR}/scripts/helpers.sh" "$text" "$width" "$offset" "$padding")"
+    assert_eq "$expected" "$actual" "$message"
+}
+
 write_tmux_mock() {
     cat > "${TMP_DIR}/tmux" <<'MOCK'
 #!/usr/bin/env bash
@@ -317,6 +335,15 @@ assert_adapter_rejected $'Playing\tArtist\tTitle\tExtra' "extra-tab adapter outp
 assert_adapter_rejected $'\tArtist\tTitle' "empty-status adapter output"
 assert_adapter_rejected $'Playing\tArtist\tTitle\nSecond' "multiline adapter output"
 assert_adapter_rejected $'Playing\tArtist\tTitle\r' "carriage-return adapter output"
+
+assert_scrolling_text "abcde" "abcde" 5 "::" 99 "scrolling returns text that exactly fits"
+assert_scrolling_text "abcd" "abcde" 4 "::" 0 "scrolling starts at first position"
+assert_scrolling_text "e::a" "abcde" 4 "::" 4 "scrolling crosses into padding"
+assert_scrolling_text "::ab" "abcde" 4 "::" 5 "scrolling starts at padding"
+assert_scrolling_text ":abc" "abcde" 4 "::" 6 "scrolling starts at last cycle offset"
+assert_scrolling_text "abcd" "abcde" 4 "::" 7 "scrolling wraps at cycle length"
+assert_scrolling_text ":abc" "abcde" 4 "::" 13 "scrolling normalizes large offsets"
+assert_scrolling_text "eabc" "abcde" 4 "" 4 "scrolling crosses empty-padding boundary"
 
 write_uname_mock
 


### PR DESCRIPTION
## Summary

- delete the unreachable secondary wrap branch in `scrolling_text`
- keep the duplicated text buffer as the single cycle-boundary mechanism
- add focused scrolling boundary tests, including empty padding

## Proof

After the early return, let text length be `L`, width be `W`, padding length be `P`, and normalized start position be `S`. The scrolling path has `L > W`, so `W <= L - 1`. The caller provides a nonnegative offset and width of at least 4, so for cycle length `L + P`, `0 <= S <= L + P - 1`.

Therefore:

```
S + W <= (L + P - 1) + (L - 1) = 2L + P - 2
```

The duplicated buffer `${text}${padding}${text}` has length `2L + P`, so every visible slice ends before that buffer ends. The deleted fallback branch cannot execute.

## Behavior preservation

The old reachable path and the simplified implementation both run:

```bash
printf '%.*s\n' "$max_width" "${padded_text:$start_pos}"
```

The duplicated text still handles crossing the conceptual cycle boundary. No output behavior changes.

## Tests

- `bash -n nowplaying.tmux scripts/*.sh`
- `./scripts/test.sh`
- `shellcheck nowplaying.tmux scripts/*.sh`
- direct checks for exact fit, initial position, text-to-padding crossing, padding start, final cycle offset, exact cycle wrap, large offset normalization, and empty padding

All checks pass.

## Residual risks

- Direct malformed width or offset inputs remain unsupported; the production caller validates width and generates a numeric, nonnegative offset.
- Bash string length and slicing do not model terminal-cell width for combining or double-width Unicode characters; this is pre-existing.
- Bash 3.2 source compatibility is preserved, but an actual Bash 3.2 executable was unavailable for runtime validation.