### PR TITLE
ci: validate Linux and macOS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,42 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  linux:
+    name: Linux
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install tools
+        run: |
+          sudo apt-get update
+          sudo apt-get install --no-install-recommends --yes shellcheck tmux
+      - name: Check shell syntax
+        run: bash -n nowplaying.tmux scripts/*.sh
+      - name: Run ShellCheck
+        run: shellcheck -x nowplaying.tmux scripts/*.sh
+      - name: Run tests
+        run: ./scripts/test.sh
+
+  macos:
+    name: macOS
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Test with system Bash 3.2
+        env:
+          PATH: /usr/bin:/bin:/usr/sbin:/sbin
+        run: |
+          /bin/bash --version
+          /bin/bash -n nowplaying.tmux scripts/*.sh
+          /bin/bash ./scripts/test.sh
+      - name: Type-check MediaRemote adapter
+        run: swiftc -typecheck scripts/nowplaying_mediaremote.swift


### PR DESCRIPTION
## Summary

- run shell syntax, ShellCheck, and regression tests on Linux
- exercise the suite with macOS system Bash 3.2
- type-check the Swift MediaRemote adapter on macOS
- keep workflow permissions read-only

## Local validation

- `actionlint .github/workflows/ci.yml`
- `bash -n nowplaying.tmux scripts/*.sh`
- `shellcheck -x nowplaying.tmux scripts/*.sh`
- `./scripts/test.sh`

All local checks pass. The GitHub-hosted macOS job provides the unavailable local Swift and Bash 3.2 validation.
